### PR TITLE
Need elevated privilege for kubectl installation via az command

### DIFF
--- a/labs/helper-files/jumpbox-setup.md
+++ b/labs/helper-files/jumpbox-setup.md
@@ -84,7 +84,7 @@ Install Kubectl command line utility to interact with AKS. There are two ways to
 
 **First method:**
 ```
-az aks install-cli
+sudo az aks install-cli
 ```
 
 **Second method:**


### PR DESCRIPTION
$ az aks install-cli
Downloading client to "/usr/local/bin/kubectl" from "https://storage.googleapis.com/kubernetes-release/release/v1.13.3/bin/linux/amd64/kubectl"
Connection error while attempting to download client ([Errno 13] Permission denied: '/usr/local/bin/kubectl')

$ sudo az aks install-cli
Downloading client to "/usr/local/bin/kubectl" from "https://storage.googleapis.com/kubernetes-release/release/v1.13.3/bin/linux/amd64/kubectl"
Please ensure that /usr/local/bin is in your search PATH, so the `kubectl` command can be found.