### PR TITLE
aciRegion parameter missing in the helm command

### DIFF
--- a/labs/day2-labs/virtual-kubelet-aci.md
+++ b/labs/day2-labs/virtual-kubelet-aci.md
@@ -123,7 +123,7 @@ eastus,virtual-kubelet-east,virtual-kubelet-east
 Now install the Helm package for Virtual Kubelet:
 ```console
 helm install ~/virtual-kubelet/charts/virtual-kubelet-for-aks/  --name "$RELEASE_NAME" \
-    --set env.azureClientId="$AZURE_CLIENT_ID",env.azureClientKey="$AZURE_CLIENT_SECRET",env.azureTenantId="$AZURE_TENANT_ID",env.azureSubscriptionId="$AZURE_SUBSCRIPTION_ID",env.aciResourceGroup="$AZURE_RG",env.nodeName="$NODE_NAME",env.nodeOsType=Linux,env.apiserverCert=$cert,env.apiserverKey=$key,image.tag="$VK_IMAGE_TAG" --set rbac.Enabled=true
+    --set env.azureClientId="$AZURE_CLIENT_ID",env.azureClientKey="$AZURE_CLIENT_SECRET",env.azureTenantId="$AZURE_TENANT_ID",env.azureSubscriptionId="$AZURE_SUBSCRIPTION_ID",env.aciResourceGroup="$AZURE_RG",env.aciRegion="$ACI_REGION".env.nodeName="$NODE_NAME",env.nodeOsType=Linux,env.apiserverCert=$cert,env.apiserverKey=$key,image.tag="$VK_IMAGE_TAG" --set rbac.Enabled=true
 ```
 
 Output:
@@ -173,7 +173,7 @@ westus,virtual-kubelet-west,virtual-kubelet-west
 Now install the Helm package for Virtual Kubelet:
 ```console
 helm install ~/virtual-kubelet/charts/virtual-kubelet-for-aks/  --name "$RELEASE_NAME" \
-    --set env.azureClientId="$AZURE_CLIENT_ID",env.azureClientKey="$AZURE_CLIENT_SECRET",env.azureTenantId="$AZURE_TENANT_ID",env.azureSubscriptionId="$AZURE_SUBSCRIPTION_ID",env.aciResourceGroup="$AZURE_RG",env.nodeName="$NODE_NAME",env.nodeOsType=Linux,env.apiserverCert=$cert,env.apiserverKey=$key,image.tag="$VK_IMAGE_TAG" --set rbac.Enabled=true
+    --set env.azureClientId="$AZURE_CLIENT_ID",env.azureClientKey="$AZURE_CLIENT_SECRET",env.azureTenantId="$AZURE_TENANT_ID",env.azureSubscriptionId="$AZURE_SUBSCRIPTION_ID",env.aciResourceGroup="$AZURE_RG",env.aciRegion="$ACI_REGION",env.nodeName="$NODE_NAME",env.nodeOsType=Linux,env.apiserverCert=$cert,env.apiserverKey=$key,image.tag="$VK_IMAGE_TAG" --set rbac.Enabled=true
 ```
 
 Output:


### PR DESCRIPTION
The aciRegion environment variable is not specified in the helm command and therefore both virtual kubelets will create nodes pointing to ACIs in the the default region set for the Azure subscription and not the regions specified in the lab.