### PR TITLE
incorrect nodeName parameter in the yaml files

### DIFF
--- a/labs/day2-labs/virtual-kubelet-aci.md
+++ b/labs/day2-labs/virtual-kubelet-aci.md
@@ -227,7 +227,7 @@ aks-nodepool1-39289454-2                    Ready     agent     22h       v1.7.7
 
 ## Schedule a pod in ACI
 
-We will use a nodeName constraint to force the scheduler to schedule the pod to the new virtual-kubelet-east node. The yaml file is included in `~/blackbelt-aks-hackfest/labs/helper-files/east-aci-heroes.yaml`. Edit the file to point to your Azure Container Registry, edit the dnsnamelabel to add some random number,and have your CosmosDB MongoDb connection String:
+We will use a nodeName constraint to force the scheduler to schedule the pod to the new virtual-kubelet-east node. The yaml file is included in `~/blackbelt-aks-hackfest/labs/helper-files/east-aci-heroes.yaml`. Edit the file to point to your Azure Container Registry, edit the dnsnamelabel to add some random number and have your CosmosDB MongoDb connection String:
 
 ```yaml
 apiVersion: v1

--- a/labs/day2-labs/virtual-kubelet-aci.md
+++ b/labs/day2-labs/virtual-kubelet-aci.md
@@ -227,7 +227,7 @@ aks-nodepool1-39289454-2                    Ready     agent     22h       v1.7.7
 
 ## Schedule a pod in ACI
 
-We will use a nodeName constraint to force the scheduler to schedule the pod to the new virtual-kubelet-east node. The yaml file is included in `~/blackbelt-aks-hackfest/labs/helper-files/east-aci-heroes.yaml`. Edit the file to point to your Azure Container Registry, edit the dnsnamelabel to add some random number and have your CosmosDB MongoDb connection String:
+We will use a nodeName constraint to force the scheduler to schedule the pod to the new virtual-kubelet-east node. The yaml file is included in `~/blackbelt-aks-hackfest/labs/helper-files/east-aci-heroes.yaml`. Edit the file to point to your Azure Container Registry, edit the dnsnamelabel to add some random number,and have your CosmosDB MongoDb connection String:
 
 ```yaml
 apiVersion: v1
@@ -274,6 +274,12 @@ spec:
       protocol: TCP
   dnsPolicy: ClusterFirst
   nodeName: virtual-kubelet-east
+  ```
+
+Before applying the yaml file be sure that the *nodeName* parameter corresponds to the node name of the east virtual kubelet created above:
+
+  ```console
+  kubectl get nodes
   ```
 
   ```console
@@ -331,6 +337,12 @@ spec:
   nodeName: virtual-kubelet-west
 ```
 
+Before applying the yaml file be sure that the *nodeName* parameter corresponds to the node name of the west virtual kubelet created above:
+
+  ```console
+  kubectl get nodes
+  ```
+  
 ```console
 kubectl apply -f west-aci-heroes.yaml
 ```


### PR DESCRIPTION
The nodeName specified in the YAML files (east-aci-heroes.yaml and west-aci-heroes.yaml) in the helper-files folder does not match the name of the nodes created by the helm command (virtual kubelet nodes): either the lab documentation or the files should be corrected.